### PR TITLE
Added optional query parameter support to pdf endpoint and updated RE…

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -12,14 +12,16 @@ a free and open-source api that runs [puppeteer](https://developers.google.com/w
 
 # table of contents
 
+- [table of contents](#table-of-contents)
 - [usage](#usage)
-    1. [screenshot](#screenshot)
-    2. [metrics](#metrics)
-    3. [trace](#trace)
-    4. [pdf](#pdf)
-    5. [meta](#meta)
-    6. [duckduckgo_profiles](#duckduckgo_profiles)
-    7. [version](#version)
+  - [endpoints](#endpoints)
+    - [screenshot](#screenshot)
+    - [metrics](#metrics)
+    - [trace](#trace)
+    - [pdf](#pdf)
+    - [meta](#meta)
+    - [duckduckgo_profiles](#duckduckgo_profiles)
+    - [version](#version)
 - [contributing](#contributing)
 - [credits](#credits)
 - [license](#license)
@@ -107,6 +109,15 @@ View the trace in [timeline-viewer](https://github.com/ChromeDevTools/timeline-v
 - method: `GET`
 - api: `https://pptr.io/api/pdf?url=https://netflix.com`
 - source: [pdf.js](/api/pdf.js)
+
+| optional params | type | description | default |
+| --- | --- | --- | --- |
+| `width` | number\|string | width of the paper, units allowed are `px`, `in`, `cm` and `mm` where default is `px`. | `1920` |
+| `height` | number\|string | height of the paper, units allowed are `px`, `in`, `cm` and `mm` where default is `px` | `1080` |
+| `scale` | 0.1<=number<=2> | scale of webpage rendering | `1` |
+| `landscape` | boolean | when `true`, the orientation of the paper is in landscape mode. | `false` |
+| `printBackground` | boolean | when `true`, the background graphics of the page are printed as well. | `false` |
+| `format` | string | overrides width/height and can be any of `Letter`, `Legal`, `Tabloid`, `Ledger`, `A0`, `A1`, `A2`, `A3`, `A4`, `A5` or `A6`. | `Letter` |
 
 ### meta
 

--- a/api/pdf.js
+++ b/api/pdf.js
@@ -1,9 +1,31 @@
 const puppeteer = require("puppeteer-core");
 const chrome = require("chrome-aws-lambda");
 
+const ALLOWED_FORMATS = ["Letter", "Legal", "Tabloid", "Ledger", "A0", "A1", "A2", "A3", "A4", "A5", "A6"];
+const ALLOWED_UNITS = ["px", "in", "cm", "mm"];
+
 module.exports = async (req, res) => {
   try {
     const url = req.query.url;
+
+    const scale = req.query.scale ? Number(req.query.scale) <= 2 && Number(req.query.scale) >= 0.1 ? Number(req.query.scale) : 1 : 1;
+    const printBackground = req.query.printBackground ? req.query.printBackground.toString().toLowerCase() === "true" ? true : false : false;
+    const landscape = req.query.landscape ? req.query.landscape.toString().toLowerCase() === "true" ? true : false : false;
+    const format = ALLOWED_FORMATS.includes(req.query.format?.toString()) ? req.query.format.toString() : undefined; // case sensitive
+    
+    const widthRaw = req.query.width?.split(/([0-9.]+)/)?.filter(s => s !== ""); // splits into numerical value and unit ("10cm" -> ["10","cm"])
+    let width;
+    if(widthRaw?.length === 1 && Number(widthRaw[0])) 
+    width = Number(widthRaw[0]);
+    else if(widthRaw?.length === 2 && Number(widthRaw[0]) && ALLOWED_UNITS.includes(widthRaw[1].toLowerCase())) 
+    width = widthRaw.join("").toLowerCase();
+    
+    const heightRaw = req.query.width?.split(/([0-9.]+)/)?.filter(s => s !== ""); // splits into numerical value and unit ("10cm" -> ["10","cm"])
+    let height;
+    if(heightRaw?.length === 1 && Number(heightRaw?.[0])) 
+    height = Number(heightRaw[0]);
+    else if(heightRaw?.length === 2 && Number(heightRaw[0]) && ALLOWED_UNITS.includes(heightRaw[1].toLowerCase())) 
+    height = heightRaw.join("").toLowerCase();
 
     const browser = await puppeteer.launch({
       args: [...chrome.args, "--hide-scrollbars", "--disable-web-security"],
@@ -19,9 +41,12 @@ module.exports = async (req, res) => {
 
     const pdf = await page.pdf({
       pageRanges: "1",
-      printBackground: true,
-      landscape: true,
-      format: "A4",
+      printBackground: printBackground,
+      landscape: landscape,
+      format: (!format && !width && !height ? "Letter" : undefined),
+      height: height,
+      width: width, 
+      scale: scale
     });
     await browser.close();
 


### PR DESCRIPTION
Added optional query parameter support for the following options for pdf:
- `scale`
- `width`
- `height`
- `format`
- `landscape`
- `printBackground`

And updated the readme to reflect these changes (with a table of the above specified optional parameters)